### PR TITLE
Fix spelling of 'transferred'

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 nload is a console application which monitors network traffic and bandwidth
 usage in real time. It visualizes the in- and outgoing traffic using two
-graphs and provides additional info like total amount of transfered data and
+graphs and provides additional info like total amount of transferred data and
 min/max network usage.
 
 ## Installing / Compiling nload

--- a/docs/nload.1.in
+++ b/docs/nload.1.in
@@ -29,7 +29,7 @@ nload \- displays the current network usage
 .B nload
 is a console application which monitors network traffic and bandwidth usage in real time.
 It visualizes the in- and outgoing traffic using two graphs and provides additional info
-like the total amount of transfered data and min/max network usage.
+like the total amount of transferred data and min/max network usage.
 
 .SH USAGE
 When running

--- a/nload.spec.in
+++ b/nload.spec.in
@@ -15,7 +15,7 @@ BuildRequires  : ncurses-devel >= 5.0
 %description
 %{name} is a console application which monitors network traffic and bandwidth
 usage in real time. It visualizes the in and outgoing traffic using two graphs
-and provides additional info like total amount of transfered data and min/max
+and provides additional info like total amount of transferred data and min/max
 network usage.
 
 


### PR DESCRIPTION
Hi,

This PR fixes the following typo:

```sed
s/transfered/transferred/
```

I noticed the typo while reading the manual page but took the opportunity to fix it at other places also.

Kind regards,
Olivier