### PR TITLE
Makefile,spec: don't compress the man-page

### DIFF
--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -1,11 +1,3 @@
 ## Helder Correia <helder.correia@netcabo.pt>
 
-man1_MAN = nload.1
-
-install:
-	$(mkinstalldirs) $(DESTDIR)$(mandir)/man1
-	$(INSTALL_DATA) $(top_builddir)/docs/$(PACKAGE).1 $(DESTDIR)$(mandir)/man1
-	gzip -f $(DESTDIR)$(mandir)/man1/$(PACKAGE).1
-
-uninstall:
-	rm $(DESTDIR)$(mandir)/man1/$(PACKAGE).1.gz
+man1_MANS = nload.1

--- a/nload.spec.in
+++ b/nload.spec.in
@@ -41,7 +41,7 @@ rm -rf %{buildroot}
 %defattr(-,root,root)
 %doc AUTHORS COPYING ChangeLog README.md
 %attr(0755,root,root) %{_bindir}/%{name}
-%{_mandir}/man1/%{name}.1.gz
+%{_mandir}/man1/%{name}.1*
 
 
 %changelog


### PR DESCRIPTION
Package managers like to compress man-pages on their own,
because the type of compression for man-pages is user-configurable.
In particular, Gentoo [1] doesn't want packages to compress their man-pages.
Gentoo Portage has workarounds for this,
but this is not specified in Package Manager Specification and
results in extra compression-decompression pass.

RPM also compresses man-pages itself (in `brp-compress`)
(and similarly recompresses them as needed)
rather than relying on packages to install compressed man-pages.

Automake can handle installation of man-pages without the explicit "install" target,
so use the standard automake-provided way of installing man-pages.
It's also smart enough to package `nload.1.in` automatically.

Don't specify an explicit man-page extension in .spec file as recommended by Fedora.

[1] https://github.com/gentoo/gentoo/pull/9543#issuecomment-415662844