### PR TITLE
Implement circular navigation for interfaces in traffic_window

### DIFF
--- a/src/traffic_window.cpp
+++ b/src/traffic_window.cpp
@@ -61,8 +61,11 @@ void TrafficWindow::printTraffic(const vector<DeviceView*>& deviceViews)
     if(deviceViews.empty())
         return;
 
-    if((unsigned int) m_curDev >= deviceViews.size() || m_curDev < 0)
-        m_curDev = 0;
+    if(m_curDev < 0)
+        m_curDev = (int)deviceViews.size() + (m_curDev % (int)deviceViews.size());
+
+    if(m_curDev >= (int)deviceViews.size())
+        m_curDev %= (int)deviceViews.size();
 
     // print data of the current device(s)
     if(!showMultipleDevices())


### PR DESCRIPTION
This commit introduces a change that implements circular navigation for interfaces in traffic_window.