### PR TITLE
Move to 'block' characters for bar graph display

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -80,15 +80,15 @@ case $host_os in
 esac
 
 dnl Checks for libraries.
-AC_CHECK_LIB(ncurses, initscr)
+AC_CHECK_LIB(ncursesw, initscr)
 AC_CHECK_LIB(form, new_form)
 
 dnl Checks for header files.
 AC_HEADER_STDC
 AC_CHECK_HEADERS([limits.h stdlib.h string.h unistd.h curses.h form.h ncurses/form.h math.h sys/param.h sys/socket.h sys/time.h sys/ioctl.h arpa/inet.h netinet/in.h])
 
-if test "$ac_cv_lib_ncurses_initscr" != "yes"; then
-    AC_MSG_ERROR([ncurses library not found. ncurses is required for $PACKAGE_NAME.])
+if test "$ac_cv_lib_ncursesw_initscr" != "yes"; then
+    AC_MSG_ERROR([ncursesw library not found. ncursesw is required for $PACKAGE_NAME.])
 fi
 if test "$ac_cv_header_curses_h" != "yes"; then
     AC_MSG_ERROR([ncurses development files not found. ncurses is required for $PACKAGE_NAME.])

--- a/src/graph.cpp
+++ b/src/graph.cpp
@@ -101,11 +101,11 @@ void Graph::print(Window& window, int x, int y)
                 unsigned long long restOfTraffic = *r - lowerLimit;
 
                 if(restOfTraffic >= trafficPerLine)
-                    window.print('#');
+                    window.print("█");
                 else if(restOfTraffic >= trafficPerLine * 7 / 10)
-                    window.print('|');
+                    window.print("▟");
                 else if(restOfTraffic >= trafficPerLine * 3 / 10)
-                    window.print('.');
+                    window.print("▗");
                 else
                     window.print(' ');
             }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -26,6 +26,7 @@
 #include <vector>
 
 #include <signal.h>
+#include <locale.h>
 
 using namespace std;
 
@@ -35,6 +36,7 @@ static void signalHandler(int signal);
 
 int main(int argc, char *argv[])
 {
+    setlocale(LC_ALL, "");
     App application;
     m_application = &application;
 


### PR DESCRIPTION
This change modifies the characters used to display the "progressbars"
of the graph. Instead of being purely ascii characters such as `#`, `|`,
and `.`, it uses longer 'block elements' characters `█`, `▟`, and `▗`,
respectively. On terminals which support it, this makes for a much
improved visual display.

Here's an example of the bar-graph output with this change:
```
Device xxxxxxxx [192.168.100.212] (3/3):     
=========================================================     
Incoming (100% @ 256 MBit/s):     
     
                                   Cur: 594.95 kBit/s     
   ▗   ▗▗                          Avg: 7.75 MBit/s     
  ████████▟▟▟                      Min: 0.00 Bit/s     
 ▗████████████▟██                  Max: 147.28 MBit/s     
 █████████████████                 Ttl: 42.43 GByte     
Outgoing (100% @ 32 MBit/s):     
                                   Cur: 23.57 MBit/s     
                            ▗█▟▟▗▗ Avg: 748.59 kBit/s     
                            ██████ Min: 0.00 Bit/s     
                           ▗██████ Max: 25.71 MBit/s     
                 ▗▗        ███████ Ttl: 5.03 GByte     

```

This is accomplished by swapping the characters being printed, then by
changing the program/build system slightly so that it will link against
`ncursesw` (the version of ncurses which supports full-width characters
instead of only purely ascii).

Since this change would permanently shift this entire codebase so that
it uses ncursesw instead of "classic ncurses", and since it would
_force_ the use of multiwidth 'block' characters which may not be
compatible with many of the original terminals where nload is used, I
don't recommend upstreaming this change to nload, at least not until
someone makes further changes which make this a toggle-able setting and
which maintains total backwards compatibility with systems where
ncursesw isn't available.

Until then, this change will exist as an option for those who want it
(like me), and as an example for the interested.